### PR TITLE
Assembly location is forwarded to Assembly Definition

### DIFF
--- a/src/FasterReflection/AssemblyDefinition.cs
+++ b/src/FasterReflection/AssemblyDefinition.cs
@@ -7,10 +7,11 @@ namespace FasterReflection
     /// </summary>
     public sealed class AssemblyDefinition
     {
-        internal AssemblyDefinition(string name, Version version)
+        internal AssemblyDefinition(string name, Version version, string location)
         {
             Name = name;
             Version = version;
+            Location = location;
         }
 
         /// <summary>
@@ -22,5 +23,6 @@ namespace FasterReflection
         /// Gets the version.
         /// </summary>
         public Version Version { get; }
+        public string Location { get; }
     }
 }

--- a/src/FasterReflection/ReflectionMetadataBuilder.cs
+++ b/src/FasterReflection/ReflectionMetadataBuilder.cs
@@ -480,7 +480,7 @@ namespace FasterReflection
                 MetadataReader = _peReader.GetMetadataReader();
                 var assemblyDefinition = MetadataReader.GetAssemblyDefinition();
                 Assembly = new AssemblyDefinition(MetadataReader.GetString(assemblyDefinition.Name),
-                    assemblyDefinition.Version);
+                    assemblyDefinition.Version, assemblyData.Location);
                 References = MetadataReader.AssemblyReferences.Select(t => MetadataReader.GetAssemblyReference(t)).ToImmutableArray();
             }
 


### PR DESCRIPTION
Forwards the location to the AssemblyDefinition and, thus, it is possible to figure out which assembly was located.