### PR TITLE
Added possibility to ignore duplicate assemblies

### DIFF
--- a/src/FasterReflection/IReflectionMetadataBuilder.cs
+++ b/src/FasterReflection/IReflectionMetadataBuilder.cs
@@ -21,7 +21,8 @@ namespace FasterReflection
         /// <summary>
         /// Gets the type definitions and a list of missing assemblies.
         /// </summary>
-        ReflectionMetadataResult Build();
+        /// <param name="ingoreDuplicateAssemblies">Ignores exception when the same assembly gets loaded multiple times</param>
+        ReflectionMetadataResult Build(bool ingoreDuplicateAssemblies = false);
 
         /// <summary>
         /// Determines whether to skip native (C++) types. The default is <c>true</c>.


### PR DESCRIPTION
Hi,
I made another change to catch duplicate assembly / assembly load exception when calling `Build(...)` on metadatabuilder. The default behavior should be preserved.

I needed this for my module loader to prevent another workaround. Maybe you like it, then pull it, otherwise reject.

Thanks